### PR TITLE
Don't use CARGO_MANIFEST_DIR in include!() path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/load.rs"));
+include!("src/load.rs");
 
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=assets/oid_db.txt");


### PR DESCRIPTION
`include!()` [expects](https://doc.rust-lang.org/std/macro.include.html) a path relative to the current file, so we don't need to dynamically construct its argument at all. In fact, the current argument breaks the build when `CARGO_MANIFEST_DIR` holds a relative path from the working directory and the working directory isn't the crate root.

This contribution is on behalf of my company.