### PR TITLE
Changes the license field to valid SPDX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oid-registry"
 version = "0.6.1"
 authors = ["Pierre Chifflier <chifflier@wzdftpd.net>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Object Identifier (OID) database"
 keywords = ["BER", "DER", "OID"]
 homepage = "https://github.com/rusticata/oid-registry"


### PR DESCRIPTION
We believe this is currently causing our dependency reviews to fail like:

<img width="968" alt="image" src="https://user-images.githubusercontent.com/13578537/210896713-a9e73d94-ea2a-464b-a4b6-3e11626c1612.png">