### PR TITLE
Don’t include .gitignore in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.65"
 include = [
   "LICENSE-*",
   "README.md",
-  ".gitignore",
   "Cargo.toml",
   "assets/*.txt",
   "build.rs",


### PR DESCRIPTION
It’s not really harmful, but it’s kind of an odd thing to explicitly and manually include.

(Downstream in Fedora, stray VCS files like these are flagged by our tooling as things that we likely shouldn’t package, which is how I noticed this.)